### PR TITLE
Update to the 2015 Q1 release of GCC 4.9

### DIFF
--- a/gcc-arm-none-eabi-49.rb
+++ b/gcc-arm-none-eabi-49.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class GccArmNoneEabi49 < Formula
   homepage 'https://launchpad.net/gcc-arm-embdded'
-  version '20141203'
-  url 'http://launchpadlibrarian.net/192227901/gcc-arm-none-eabi-4_9-2014q4-20141203-mac.tar.bz2'
-  sha1 '46767b358cc42ffe126aec68afb9d22bd0ef5beb'
+  version '20150306'
+  url 'https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q1-update/+download/gcc-arm-none-eabi-4_9-2015q1-20150306-mac.tar.bz2'
+  sha1 'da07fd4edc09da8748b3a61252eed793059c138f'
 
   def install 
     ohai 'Copying binaries...'


### PR DESCRIPTION
This patch updates the GCC 4.9 to the latest quarterly release from LaunchPad.