### PR TITLE
Updates to the latest available 4.9.3 release

### DIFF
--- a/gcc-arm-none-eabi-49.rb
+++ b/gcc-arm-none-eabi-49.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class GccArmNoneEabi49 < Formula
   homepage 'https://launchpad.net/gcc-arm-embdded'
-  version '20150306'
-  url 'https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q1-update/+download/gcc-arm-none-eabi-4_9-2015q1-20150306-mac.tar.bz2'
-  sha1 'da07fd4edc09da8748b3a61252eed793059c138f'
+  version '20150609'
+  url 'https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q2-update/+download/gcc-arm-none-eabi-4_9-2015q2-20150609-mac.tar.bz2'
+  sha1 '7f2d8c3644cd76da1b78d17a0770c8c0efbff957'
 
   def install 
     ohai 'Copying binaries...'


### PR DESCRIPTION
 `arm-none-eabi-gcc --version` now says `4.9.3 20150529`, used to say `4.9.3 20150303`