### PR TITLE
Add El Capitan support to kconfig-frontends

### DIFF
--- a/kconfig-frontends.rb
+++ b/kconfig-frontends.rb
@@ -16,6 +16,7 @@ class KconfigFrontends < Formula
     root_url 'http://pixhawk.org/_media/downloads'
     sha1 "091c9a00ed9d84d4cc1603d60b81ef120d51f173" => :mavericks
     sha1 "091c9a00ed9d84d4cc1603d60b81ef120d51f173" => :yosemite
+    sha1 "091c9a00ed9d84d4cc1603d60b81ef120d51f173" => :el_capitan
   end
 
   def patches


### PR DESCRIPTION
**Prior to merging** a copy of http://pixhawk.org/_media/downloads/kconfig-frontends-3.7.0.0.yosemite.bottle.tar.gz will need to be available at http://pixhawk.org/_media/downloads/kconfig-frontends-3.7.0.0.el_capitan.bottle.tar.gz.

This relates to #4, only for El Capitan instead of Yosemite. Tested on OS X 10.11.1 by pointing `root_url` to a local server.

Thank you for simplifying development with NuttX on OS X!