### PR TITLE
update gcc-arm-none-eabi-54.rb

### DIFF
--- a/gcc-arm-none-eabi-54.rb
+++ b/gcc-arm-none-eabi-54.rb
@@ -2,10 +2,10 @@ require 'formula'
 
 class GccArmNoneEabi54 < Formula
   homepage 'https://launchpad.net/gcc-arm-embedded'
-  version '20160628'
-  url 'https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q2-update/+download/gcc-arm-none-eabi-5_4-2016q2-20160622-mac.tar.bz2'
-  sha256 'e175a0eb7ee312013d9078a5031a14bf14dff82c7e697549f04b22e6084264c8'
-
+  version '20160926'
+  url 'https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q3-update/+download/gcc-arm-none-eabi-5_4-2016q3-20160926-mac.tar.bz2'
+  sha256 '5656cdec40f99d5c054a85bbc694276e1c4a1488cdacbbc448bc6acd3bbe070d'
+  
   def install 
     ohai 'Copying binaries...'
     system 'cp', '-rv', 'arm-none-eabi', 'bin', 'lib', 'share', "#{prefix}/"


### PR DESCRIPTION
updated to reflect 5-2016-q3-update release to 5_4