### PR TITLE
Adding pkgconfig dependency to build kconfig-frontends.

### DIFF
--- a/kconfig-frontends.rb
+++ b/kconfig-frontends.rb
@@ -10,6 +10,7 @@ class KconfigFrontends < Formula
   depends_on 'automake' => :build
   depends_on 'autoconf' => :build
   depends_on 'libtool' => :build
+  depends_on 'pkgconfig' => :build
 
   bottle do
     #cellar :any


### PR DESCRIPTION
This fixes the issue of failing to build properly on systems that do not have pkgconfig with unrelated messages such as:

Running autoconf...
configure.ac:27: error: possibly undefined macro: AS_IF
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure.ac:101: error: possibly undefined macro: AC_MSG_ERROR