### PR TITLE
Add GCC 6.3 from official ARM repo

### DIFF
--- a/gcc-arm-none-eabi-63.rb
+++ b/gcc-arm-none-eabi-63.rb
@@ -1,0 +1,13 @@
+require 'formula'
+
+class GccArmNoneEabi63 < Formula
+  homepage 'https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads'
+  version '20170223'
+  url 'https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/6_1-2017q1/gcc-arm-none-eabi-6-2017-q1-update-mac.tar.bz2'
+  sha256 'de4de95b09740272aa95ca5a43bb234ba29c323eddcad2ee34e901eebda910a2'
+
+  def install
+    ohai 'Copying binaries...'
+    system 'cp', '-r', 'arm-none-eabi', 'bin', 'lib', 'share', "#{prefix}/"
+  end
+end


### PR DESCRIPTION
GDB 6.2 is very inclined to crash on macOS. This issue is fixed in the 6.3 toolchain.
See: https://bugs.launchpad.net/gcc-arm-embedded/+bug/1655778