### PR TITLE
Bump gazebo version to 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ language: ruby
 matrix:
   include:
     - name: Test on MacOS High Sierra
-      env: OSX=10.13
       os: osx
       osx_image: xcode10.1
       rvm: system
     - name: Test on MacOS Sierra
-      env: OSX=10.12
       os: osx
       osx_image: xcode9.2
       rvm: system
@@ -21,7 +19,10 @@ before_install:
   - if [ -f ".git/shallow" ]; then
       travis_retry git fetch --unshallow;
     fi
-  - sudo chown -R $USER "$(brew --repo)"
+  - echo $USER
+  - sudo chown -R $USER $(brew --repo)
+  - sudo chown -R $USER $(brew --prefix)/*
+  - sudo chown -R $USER /usr/local/lib/python2.7/
   - git -C "$(brew --repo)" reset --hard origin/master
   - git -C "$(brew --repo)" clean -qxdff
   - export HOMEBREW_DEVELOPER="1"
@@ -37,6 +38,3 @@ script:
   - brew audit $(brew --repo $TRAVIS_REPO_SLUG)/Formula/*.rb
   - brew style $(brew --repo $TRAVIS_REPO_SLUG)/Formula/*.rb
   - brew install px4-sim
-  - if [[ "$OSX" == "10.12" ]]; then
-      brew link --overwrite numpy;
-    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ matrix:
       os: osx
       osx_image: xcode10.1
       rvm: system
-    - name: Test on MacOS Sierra
-      os: osx
-      osx_image: xcode9.2
-      rvm: system
 
 cache:
   directories:
@@ -21,8 +17,6 @@ before_install:
     fi
   - echo $USER
   - sudo chown -R $USER $(brew --repo)
-  - sudo chown -R $USER $(brew --prefix)/*
-  - sudo chown -R $USER /usr/local/lib/python2.7/
   - git -C "$(brew --repo)" reset --hard origin/master
   - git -C "$(brew --repo)" clean -qxdff
   - export HOMEBREW_DEVELOPER="1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,6 @@ script:
   - brew audit $(brew --repo $TRAVIS_REPO_SLUG)/Formula/*.rb
   - brew style $(brew --repo $TRAVIS_REPO_SLUG)/Formula/*.rb
   - brew install px4-sim
-  - if [[ "$OSX" == "10.12" ]; then
+  - if [[ "$OSX" == "10.12" ]]; then
       brew link --overwrite numpy;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: ruby
 matrix:
   include:
     - name: Test on MacOS High Sierra
+      env: OSX=10.13
       os: osx
       osx_image: xcode10.1
       rvm: system
     - name: Test on MacOS Sierra
+      env: OSX=10.12
       os: osx
       osx_image: xcode9.2
       rvm: system
@@ -35,3 +37,6 @@ script:
   - brew audit $(brew --repo $TRAVIS_REPO_SLUG)/Formula/*.rb
   - brew style $(brew --repo $TRAVIS_REPO_SLUG)/Formula/*.rb
   - brew install px4-sim
+  - if [[ "$OSX" == "10.12" ]; then
+      brew link --overwrite numpy;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: ruby
 matrix:
   include:
-    - env: OSX=10.13
+    - name: Test on MacOS High Sierra
       os: osx
       osx_image: xcode10.1
+      rvm: system
+    - name: Test on MacOS Sierra
+      os: osx
+      osx_image: xcode9.2
       rvm: system
 
 cache:

--- a/Formula/px4-sim.rb
+++ b/Formula/px4-sim.rb
@@ -9,7 +9,7 @@ class Px4Sim < Formula
   depends_on "exiftool"
   depends_on "graphviz"
   depends_on "opencv"
-  depends_on "osrf/simulation/gazebo8"
+  depends_on "osrf/simulation/gazebo9"
   depends_on "protobuf"
   depends_on "px4-dev"
   depends_on :x11


### PR DESCRIPTION
It came to my attention that the `px4-sim` formula still depends on Gazebo 8, instead of 9, which is now used as the standard Gazebo version on PX4. I am not aware of compatibility issues regarding the OSX version, so if someone someone is aware that this could not work, let me know.