### PR TITLE
Travis CI: try to build the latest stable firmware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
+os: osx
+rvm: system
+
 language: ruby
 matrix:
   include:
     - env: OSX=10.13
-      os: osx
       osx_image: xcode10.1
-      rvm: system
 
 cache:
   directories:
@@ -13,7 +14,7 @@ cache:
 before_install:
   - export TRAVIS_COMMIT="$(git rev-parse --verify -q HEAD)"
   - if [ -f ".git/shallow" ]; then
-      travis_retry git fetch --unshallow;
+    travis_retry git fetch --unshallow;
     fi
   - sudo chown -R $USER "$(brew --repo)"
   - git -C "$(brew --repo)" reset --hard origin/master
@@ -28,6 +29,16 @@ before_install:
   - ulimit -n 1024
 
 script:
+  # Homebrew style checks
   - brew audit $(brew --repo $TRAVIS_REPO_SLUG)/Formula/*.rb
   - brew style $(brew --repo $TRAVIS_REPO_SLUG)/Formula/*.rb
+
+  # Install the toolchain
   - brew install px4-sim
+  - sudo -H pip install --upgrade --force-reinstall numpy
+  - sudo -H pip install pyserial empy toml pandas jinja2 pyyaml
+
+  # Compile PX4 firmware
+  - git clone -b stable https://github.com/PX4/Firmware.git ~/Firmware
+  - cd ~/Firmware
+  - DONT_RUN=1 make posix_sitl_default gazebo


### PR DESCRIPTION
This PR is an improvement to the Continuous Integration system (#31).

Dependency problems in the compilation of the PX4 firmware can show themselves in three different phases:
1) installation of the toolchain
2) firmware compile-time
3) firmware run-time

Currently, the CI process on this repo catches all the problems in 1).
To catch the issues that could emerge in phase 2), it is necessary to actually compile the latest stable version of the PX4 firmware and check if the compilation succeeds.

An example of such an issue is https://github.com/osrf/homebrew-simulation/pull/558: a dependency of Gazebo gets updated, and the Gazebo bottle now contains a broken dynamic library link; Gazebo installs fine (with a warning), and the firmware compilation fails.

The next step would be to actually *run* the firmware in Gazebo and check for success, catching the type-3 issues.
However, I have no idea about how to do it non-interactively.