### PR TITLE
Gazebo 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,4 @@ script:
   # Compile PX4 firmware
   - git clone -b master https://github.com/PX4/Firmware.git ~/Firmware
   - cd ~/Firmware
-  - DONT_RUN=1 make posix_sitl_default gazebo
+  - DONT_RUN=1 make px4_sitl_default gazebo

--- a/Formula/px4-sim.rb
+++ b/Formula/px4-sim.rb
@@ -10,7 +10,7 @@ class Px4Sim < Formula
   depends_on "glog"
   depends_on "graphviz"
   depends_on "opencv"
-  depends_on "osrf/simulation/gazebo8"
+  depends_on "osrf/simulation/gazebo9"
   depends_on "protobuf"
   depends_on "px4-dev"
   depends_on :x11


### PR DESCRIPTION
Gazebo 8 has reached end of life: http://gazebosim.org/#status
It’s time to start using Gazebo 9 for macOS builds, since no more bottles will be made for Gazebo 8.
The sitl_gazebo project also did the same: https://github.com/PX4/sitl_gazebo/pull/311