### PR TITLE
.travis.yml: build also on macOS 10.14 Mojave

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ matrix:
   include:
     - env: OSX=10.13
       osx_image: xcode10.1
+    - env: OSX=10.14
+      osx_image: xcode10.2
 
 cache:
   directories:


### PR DESCRIPTION
Travis CI now supports macOS 10.14: https://blog.travis-ci.com/2019-02-12-xcode-10-2-beta-2-is-now-available