### PR TITLE
travis: trying to fix pip error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_install:
   - export TRAVIS_BUILD_DIR="$(brew --repo $TRAVIS_REPO_SLUG)"
   - cd "$(brew --repo)"
   - ulimit -n 1024
+  - brew link openssl --force
 
 script:
   # Homebrew style checks


### PR DESCRIPTION
This could fix the error when doing pip install:
```
ERROR:root:code for hash md5 was not found.
```