### PR TITLE
travis: try to fix rvm install error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 os: osx
-rvm: system
 
-language: ruby
+language: generic
 matrix:
   include:
     - osx_image: xcode9.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,10 @@ script:
   - brew audit $(brew --repo $TRAVIS_REPO_SLUG)/Formula/*.rb
   - brew style $(brew --repo $TRAVIS_REPO_SLUG)/Formula/*.rb
 
-  # Install the toolchain
-  - brew unlink python@2
+  # Install the toolchain and Python dependencies
+  - brew uninstall python python@2
+  - brew unlink python python@2
   - brew install python
-  - brew link python
   - brew install px4-sim
   - pip3 install --user --upgrade pyserial empy toml pandas jinja2 pyyaml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ script:
   - brew style $(brew --repo $TRAVIS_REPO_SLUG)/Formula/*.rb
 
   # Install the toolchain
-  - brew install px4-sim
+  - brew unlink python@2
+  - brew install px4-sim python3
   - pip3 install --user --upgrade pyserial empy toml pandas jinja2 pyyaml
 
   # Compile PX4 firmware

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
   - brew unlink python python@2
   - brew install python
   - brew install px4-sim
-  - pip3 install --user --upgrade pyserial empy toml pandas jinja2 pyyaml
+  - pip3 install --user --upgrade pyserial empy toml pandas jinja2 pyyaml pyros-genmsg
 
   # Compile PX4 firmware
   - git clone -b master https://github.com/PX4/Firmware.git ~/Firmware

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,9 @@ script:
 
   # Install the toolchain
   - brew unlink python@2
-  - brew install px4-sim python3
+  - brew install python
+  - brew link python
+  - brew install px4-sim
   - pip3 install --user --upgrade pyserial empy toml pandas jinja2 pyyaml
 
   # Compile PX4 firmware

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ matrix:
     - osx_image: xcode10.3
     - osx_image: xcode11.2
 
+branches:
+  only:
+    - master
+
+
 before_cache:
   - brew cleanup
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,7 @@ script:
 
   # Install the toolchain
   - brew install px4-sim
-  - sudo -H pip install --upgrade --force-reinstall numpy
-  - sudo -H pip install pyserial empy toml pandas jinja2 pyyaml
+  - pip3 install --user --upgrade pyserial empy toml pandas jinja2 pyyaml
 
   # Compile PX4 firmware
   - git clone -b master https://github.com/PX4/Firmware.git ~/Firmware

--- a/Formula/px4-dev.rb
+++ b/Formula/px4-dev.rb
@@ -17,6 +17,7 @@ class Px4Dev < Formula
   depends_on :java
   depends_on "kconfig-frontends"
   depends_on "ninja"
+  depends_on "python3"
 
   def install
     mkdir_p "#{bin}/"


### PR DESCRIPTION
We currently get the error below:

```
$ rvm use system --install --binary --fuzzy
curl: (22) The requested URL returned error: 404 Not Found
Now using system ruby.
** Updating RubyGems to the latest compatible version for security reasons. **
** If you need an older version, you can downgrade with 'gem update --system OLD_VERSION'. **
0.58s$ gem install bundler
Fetching: bundler-2.1.4.gem (100%)
ERROR:  While executing gem ... (Gem::FilePermissionError)
    You don't have write permissions for the /Library/Ruby/Gems/2.3.0 directory.
The command "gem install bundler" failed and exited with 1 during .
```

Therefore, let's try without specifying rvm.