### PR TITLE
Formula: depend on AdoptOpenJDK instead of Java

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - osx_image: xcode9.4
     - osx_image: xcode10.3
-    - osx_image: xcode11.2
+    - osx_image: xcode11.3
 
 branches:
   only:

--- a/Formula/px4-dev.rb
+++ b/Formula/px4-dev.rb
@@ -14,7 +14,6 @@ class Px4Dev < Formula
   depends_on "fastrtps"
   depends_on "gcc-arm-none-eabi"
   depends_on "genromfs"
-  depends_on :java
   depends_on "kconfig-frontends"
   depends_on "ninja"
   depends_on "python"

--- a/Formula/px4-sim-gazebo.rb
+++ b/Formula/px4-sim-gazebo.rb
@@ -1,0 +1,29 @@
+require "formula"
+
+class Px4SimGazebo < Formula
+  desc "PX4 Gazebo simulation"
+  homepage "http://px4.io"
+  url "https://raw.githubusercontent.com/PX4/Firmware/master/Tools/px4.py"
+  version "1.6.5.0"
+  sha256 "48199ee9ff392eff8a1efcd177e2c10f4a4dfd9877e52e13b1f3540d5dfedac9"
+  depends_on "exiftool"
+  depends_on "glog"
+  depends_on "graphviz"
+  depends_on "gst-libav"
+  depends_on "gst-plugins-bad"
+  depends_on "gst-plugins-base"
+  depends_on "gst-plugins-good"
+  depends_on "gst-plugins-ugly"
+  depends_on "gstreamer"
+  depends_on "opencv"
+  depends_on "osrf/simulation/gazebo9"
+  depends_on "protobuf"
+  depends_on "px4-dev"
+  depends_on :x11
+
+  def install
+    mkdir_p "#{bin}/"
+    cp "px4.py", "#{bin}/px4-sim.py"
+    ohai "PX4 Gazebo simulation installed"
+  end
+end

--- a/Formula/px4-sim-gazebo.rb
+++ b/Formula/px4-sim-gazebo.rb
@@ -23,7 +23,7 @@ class Px4SimGazebo < Formula
 
   def install
     mkdir_p "#{bin}/"
-    cp "px4.py", "#{bin}/px4-sim.py"
+    cp "px4.py", "#{bin}/px4-sim-gazebo.py"
     ohai "PX4 Gazebo simulation installed"
   end
 end

--- a/Formula/px4-sim-jmavsim.rb
+++ b/Formula/px4-sim-jmavsim.rb
@@ -14,7 +14,7 @@ class Px4SimJmavsim < Formula
 
   def install
     mkdir_p "#{bin}/"
-    cp "px4.py", "#{bin}/px4-sim.py"
+    cp "px4.py", "#{bin}/px4-sim-jmavsim.py"
     ohai "PX4 jMAVSim simulation installed"
   end
 end

--- a/Formula/px4-sim-jmavsim.rb
+++ b/Formula/px4-sim-jmavsim.rb
@@ -1,5 +1,9 @@
 require "formula"
 
+# This depends on AdoptOpenJdk 8 installed using:
+# brew tap adoptopenjdk/openjdk
+# brew cask install adoptopenjdk8
+
 class Px4SimJmavsim < Formula
   desc "PX4 jMAVSim simulation"
   homepage "http://px4.io"
@@ -7,7 +11,6 @@ class Px4SimJmavsim < Formula
   version "1.6.5.0"
   sha256 "48199ee9ff392eff8a1efcd177e2c10f4a4dfd9877e52e13b1f3540d5dfedac9"
   depends_on "ant"
-  depends_on :adoptopenjdk8
 
   def install
     mkdir_p "#{bin}/"

--- a/Formula/px4-sim-jmavsim.rb
+++ b/Formula/px4-sim-jmavsim.rb
@@ -1,0 +1,17 @@
+require "formula"
+
+class Px4SimJmavsim < Formula
+  desc "PX4 jMAVSim simulation"
+  homepage "http://px4.io"
+  url "https://raw.githubusercontent.com/PX4/Firmware/master/Tools/px4.py"
+  version "1.6.5.0"
+  sha256 "48199ee9ff392eff8a1efcd177e2c10f4a4dfd9877e52e13b1f3540d5dfedac9"
+  depends_on "ant"
+  depends_on :adoptopenjdk/openjdk/adoptopenjdk8
+
+  def install
+    mkdir_p "#{bin}/"
+    cp "px4.py", "#{bin}/px4-sim.py"
+    ohai "PX4 jMAVSim simulation installed"
+  end
+end

--- a/Formula/px4-sim-jmavsim.rb
+++ b/Formula/px4-sim-jmavsim.rb
@@ -7,7 +7,7 @@ class Px4SimJmavsim < Formula
   version "1.6.5.0"
   sha256 "48199ee9ff392eff8a1efcd177e2c10f4a4dfd9877e52e13b1f3540d5dfedac9"
   depends_on "ant"
-  depends_on :adoptopenjdk/openjdk/adoptopenjdk8
+  depends_on :adoptopenjdk8
 
   def install
     mkdir_p "#{bin}/"

--- a/Formula/px4-sim.rb
+++ b/Formula/px4-sim.rb
@@ -17,6 +17,7 @@ class Px4Sim < Formula
   depends_on "gstreamer"
   depends_on "opencv"
   depends_on "osrf/simulation/gazebo9"
+  depends_on cask: "adoptopenjdk/openjdk/adoptopenjdk8"
   depends_on "protobuf"
   depends_on "px4-dev"
   depends_on :x11

--- a/Formula/px4-sim.rb
+++ b/Formula/px4-sim.rb
@@ -17,7 +17,6 @@ class Px4Sim < Formula
   depends_on "gstreamer"
   depends_on "opencv"
   depends_on "osrf/simulation/gazebo9"
-  depends_on cask: "adoptopenjdk/openjdk/adoptopenjdk8"
   depends_on "protobuf"
   depends_on "px4-dev"
   depends_on :x11

--- a/Formula/px4-sim.rb
+++ b/Formula/px4-sim.rb
@@ -1,25 +1,17 @@
 require "formula"
 
+# This formula is presented for compatiliby with older instructions.
+# Going forward Gazebo and/or jMAVSim can also be installed individually using
+# px4-sim-gazebo and px4-sim-jmavsim.
+
 class Px4Sim < Formula
   desc "PX4 simulation toolchain"
   homepage "http://px4.io"
   url "https://raw.githubusercontent.com/PX4/Firmware/master/Tools/px4.py"
   version "1.6.5.0"
   sha256 "48199ee9ff392eff8a1efcd177e2c10f4a4dfd9877e52e13b1f3540d5dfedac9"
-  depends_on "exiftool"
-  depends_on "glog"
-  depends_on "graphviz"
-  depends_on "gst-libav"
-  depends_on "gst-plugins-bad"
-  depends_on "gst-plugins-base"
-  depends_on "gst-plugins-good"
-  depends_on "gst-plugins-ugly"
-  depends_on "gstreamer"
-  depends_on "opencv"
-  depends_on "osrf/simulation/gazebo9"
-  depends_on "protobuf"
-  depends_on "px4-dev"
-  depends_on :x11
+  depends_on "px4-sim-gazebo"
+  depends_on "px4-sim-jmavsim"
 
   def install
     mkdir_p "#{bin}/"


### PR DESCRIPTION
For jMAVSim we need Java 8.

I still need to test this.