### PR TITLE
Fixed SHA256 for px4-sim formulas

### DIFF
--- a/Formula/px4-sim-gazebo.rb
+++ b/Formula/px4-sim-gazebo.rb
@@ -5,7 +5,7 @@ class Px4SimGazebo < Formula
   homepage "http://px4.io"
   url "https://raw.githubusercontent.com/PX4/Firmware/master/Tools/px4.py"
   version "1.6.5.0"
-  sha256 "48199ee9ff392eff8a1efcd177e2c10f4a4dfd9877e52e13b1f3540d5dfedac9"
+  sha256 "dafe6a32d270c48cbd42960adb2155bd5f60d1aec8cb644b10f8cafc0c8d2e8f"
   depends_on "exiftool"
   depends_on "glog"
   depends_on "graphviz"

--- a/Formula/px4-sim-jmavsim.rb
+++ b/Formula/px4-sim-jmavsim.rb
@@ -9,7 +9,7 @@ class Px4SimJmavsim < Formula
   homepage "http://px4.io"
   url "https://raw.githubusercontent.com/PX4/Firmware/master/Tools/px4.py"
   version "1.6.5.0"
-  sha256 "48199ee9ff392eff8a1efcd177e2c10f4a4dfd9877e52e13b1f3540d5dfedac9"
+  sha256 "dafe6a32d270c48cbd42960adb2155bd5f60d1aec8cb644b10f8cafc0c8d2e8f"
   depends_on "ant"
   depends_on "px4-dev"
 

--- a/Formula/px4-sim.rb
+++ b/Formula/px4-sim.rb
@@ -9,7 +9,7 @@ class Px4Sim < Formula
   homepage "http://px4.io"
   url "https://raw.githubusercontent.com/PX4/Firmware/master/Tools/px4.py"
   version "1.6.5.0"
-  sha256 "48199ee9ff392eff8a1efcd177e2c10f4a4dfd9877e52e13b1f3540d5dfedac9"
+  sha256 "dafe6a32d270c48cbd42960adb2155bd5f60d1aec8cb644b10f8cafc0c8d2e8f"
   depends_on "px4-sim-gazebo"
   depends_on "px4-sim-jmavsim"
 


### PR DESCRIPTION
Fixed SHA256 for the remaining formulas (had already been fixed for `px4-dev` in #54). The remaining formulas `px4-sim, `px4-sim-gazebo`, and `px4-sim-jmavsim`were not yet updated (see PX4/Firmware#14822).