### PR TITLE
Fix error on Calling depends_on :java is disabled!

### DIFF
--- a/Formula/fastrtps.rb
+++ b/Formula/fastrtps.rb
@@ -13,7 +13,7 @@ class Fastrtps < Formula
 
   depends_on "cmake" => :build
   depends_on "gradle" => :build
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     Dir.mkdir("./build")


### PR DESCRIPTION
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/px4/homebrew-px4/Formula/fastrtps.rb
fastrtps: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.