### PR TITLE
Fixging error: Calling depends_on :java is disable

### DIFF
--- a/Formula/fastrtps15.rb
+++ b/Formula/fastrtps15.rb
@@ -16,7 +16,7 @@ class Fastrtps15 < Formula
 
   depends_on "cmake" => :build
   depends_on "gradle" => :build
-  depends_on :java
+  depends_on "openjdk"
 
   patch :p0, 'diff --git CMakeLists.txt CMakeLists.txt
 index ee7fc73b..eed6f0b4 100644


### PR DESCRIPTION
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/px4/homebrew-px4/Formula/fastrtps15.rb
fastrtps15: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.