### PR TITLE
Remove dependency on deprecate x11

### DIFF
--- a/Formula/px4-sim-gazebo.rb
+++ b/Formula/px4-sim-gazebo.rb
@@ -17,6 +17,7 @@ class Px4SimGazebo < Formula
   depends_on "osrf/simulation/gazebo11"
   depends_on "protobuf"
   depends_on "px4-dev"
+  depends_on "xquartz"
 
   def install
     mkdir_p "#{bin}/"

--- a/Formula/px4-sim-gazebo.rb
+++ b/Formula/px4-sim-gazebo.rb
@@ -17,7 +17,6 @@ class Px4SimGazebo < Formula
   depends_on "osrf/simulation/gazebo11"
   depends_on "protobuf"
   depends_on "px4-dev"
-  depends_on :x11
 
   def install
     mkdir_p "#{bin}/"


### PR DESCRIPTION
Warning: Calling depends_on :x11 is deprecated! Use depends_on specific X11 formula(e) instead.
Please report this issue to the px4/px4 tap (not Homebrew/brew or Homebrew/core)