### PR TITLE
Fix: Calling depends_on :java is disabled

### DIFF
--- a/Formula/fastrtps.rb
+++ b/Formula/fastrtps.rb
@@ -13,7 +13,7 @@ class Fastrtps < Formula
 
   depends_on "cmake" => :build
   depends_on "gradle" => :build
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     Dir.mkdir("./build")

--- a/Formula/fastrtps15.rb
+++ b/Formula/fastrtps15.rb
@@ -16,7 +16,7 @@ class Fastrtps15 < Formula
 
   depends_on "cmake" => :build
   depends_on "gradle" => :build
-  depends_on :java
+  depends_on "openjdk"
 
   patch :p0, 'diff --git CMakeLists.txt CMakeLists.txt
 index ee7fc73b..eed6f0b4 100644


### PR DESCRIPTION
Both dependencies on both files (fastrtps.rb and fastrtps15.rb) changed at the same time, should pass CI checks now.

Fix `brew install px4-dev`

Error Message: 
```
Error: fastrtps: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the px4/px4 tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/px4/homebrew-px4/Formula/fastrtps.rb:16
```

Successful Installation Output:
`brew install px4-dev`
```
==> Installing px4-dev from px4/px4
==> Downloading https://homebrew.bintray.com/bottles/openjdk-15.0.1.catalina.bottle.tar.gz
==> Downloading from https://d29vzk4ow07wi7.cloudfront.net/9376a1c6fdf8b0268b6cb56c9878358df148b530fcb0e3697596155fad3ca8d7?response-content-dispos
######################################################################## 100.0%
==> Downloading https://www.apache.org/dyn/closer.lua?path=ant/ivy/2.5.0/apache-ivy-2.5.0-bin.tar.gz
==> Downloading from https://downloads.apache.org/ant/ivy/2.5.0/apache-ivy-2.5.0-bin.tar.gz
######################################################################## 100.0%
==> Downloading https://www.apache.org/dyn/closer.lua?path=commons/bcel/binaries/bcel-6.5.0-bin.tar.gz
==> Downloading from https://kozyatagi.mirror.guzel.net.tr/apache/commons/bcel/binaries/bcel-6.5.0-bin.tar.gz
######################################################################## 100.0%
==> Downloading https://www.apache.org/dyn/closer.lua?path=ant/binaries/apache-ant-1.10.9-bin.tar.xz
==> Downloading from https://downloads.apache.org/ant/binaries/apache-ant-1.10.9-bin.tar.xz
######################################################################## 100.0%
==> Downloading https://homebrew.bintray.com/bottles/astyle-3.1.catalina.bottle.1.tar.gz
######################################################################## 100.0%
==> Downloading https://homebrew.bintray.com/bottles/bash-completion-1.3_3.catalina.bottle.tar.gz
######################################################################## 100.0%
==> Downloading https://homebrew.bintray.com/bottles/zstd-1.4.8.catalina.bottle.tar.gz
==> Downloading from https://d29vzk4ow07wi7.cloudfront.net/ad897f36994db64c4ec410c1e9324b66dcf4f2175cf7d24c62ec647921b5dc7d?response-content-dispos
######################################################################## 100.0%
==> Downloading https://homebrew.bintray.com/bottles/ccache-4.1.catalina.bottle.tar.gz
==> Downloading from https://d29vzk4ow07wi7.cloudfront.net/234a4d2ba07206b539a347adff99f283da2bf219775e30da5567140cbd7c4fdf?response-content-dispos
######################################################################## 100.0%
==> Downloading https://homebrew.bintray.com/bottles/cmake-3.19.2.catalina.bottle.tar.gz
==> Downloading from https://d29vzk4ow07wi7.cloudfront.net/4119d81cfa8435976e667af76a8b79a35f34d97aab69b646b2356eb69b8edf78?response-content-dispos
######################################################################## 100.0%
==> Downloading https://github.com/discoteq/flock/releases/download/v0.4.0/flock-0.4.0.tar.xz
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/23032276/66850580-8590-11ea-88ad-0e5db2b44c07?X-Amz-Algorithm=
######################################################################## 100.0%
==> Downloading https://github.com/eProsima/Fast-CDR/archive/v1.0.8.tar.gz
==> Downloading from https://codeload.github.com/eProsima/Fast-CDR/tar.gz/v1.0.8
######################################################################## 100.0%
==> Downloading http://px4-tools.s3.amazonaws.com/fastrtps-1.6.0.high_sierra.bottle.tar.gz
######################################################################## 100.0%
==> Downloading https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-mac.tar.bz2
==> Downloading from https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-mac.tar.bz2
######################################################################## 100.0%
==> Downloading http://px4-travis.s3.amazonaws.com/toolchain/genromfs-0.5.2.tar.gz
######################################################################## 100.0%
==> Downloading http://px4-travis.s3.amazonaws.com/toolchain/bottles/kconfig-frontends-3.7.0.0.yosemite.bottle.tar.gz
######################################################################## 100.0%
==> Downloading https://homebrew.bintray.com/bottles/ninja-1.10.2.catalina.bottle.tar.gz
######################################################################## 100.0%
==> Downloading https://raw.githubusercontent.com/PX4/Firmware/master/Tools/px4.py
######################################################################## 100.0%
==> Installing dependencies for px4/px4/px4-dev: openjdk, ant, astyle, bash-completion, zstd, ccache, cmake, discoteq/discoteq/flock, fastcdr, fastrtps, gcc-arm-none-eabi, genromfs, kconfig-frontends and ninja
==> Installing px4/px4/px4-dev dependency: openjdk
==> Pouring openjdk-15.0.1.catalina.bottle.tar.gz
==> Caveats
For the system Java wrappers to find this JDK, symlink it with
  sudo ln -sfn /usr/local/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk

openjdk is keg-only, which means it was not symlinked into /usr/local,
because it shadows the macOS `java` wrapper.

If you need to have openjdk first in your PATH run:
  echo 'export PATH="/usr/local/opt/openjdk/bin:$PATH"' >> ~/.zshrc

For compilers to find openjdk you may need to set:
  export CPPFLAGS="-I/usr/local/opt/openjdk/include"

==> Summary
🍺  /usr/local/Cellar/openjdk/15.0.1: 614 files, 324.9MB
==> Installing px4/px4/px4-dev dependency: ant
🍺  /usr/local/Cellar/ant/1.10.9: 1,668 files, 41.8MB, built in 6 seconds
==> Installing px4/px4/px4-dev dependency: astyle
==> Pouring astyle-3.1.catalina.bottle.1.tar.gz
🍺  /usr/local/Cellar/astyle/3.1: 5 files, 538.3KB
==> Installing px4/px4/px4-dev dependency: bash-completion
==> Pouring bash-completion-1.3_3.catalina.bottle.tar.gz
==> Caveats
Add the following line to your ~/.bash_profile:
  [[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
==> Summary
🍺  /usr/local/Cellar/bash-completion/1.3_3: 189 files, 607.9KB
==> Installing px4/px4/px4-dev dependency: zstd
==> Pouring zstd-1.4.8.catalina.bottle.tar.gz
🍺  /usr/local/Cellar/zstd/1.4.8: 26 files, 3.4MB
==> Installing px4/px4/px4-dev dependency: ccache
==> Pouring ccache-4.1.catalina.bottle.tar.gz
==> Caveats
To install symlinks for compilers that will automatically use
ccache, prepend this directory to your PATH:
  /usr/local/opt/ccache/libexec

If this is an upgrade and you have previously added the symlinks to
your PATH, you may need to modify it to the path specified above so
it points to the current version.

NOTE: ccache can prevent some software from compiling.
ALSO NOTE: The brew command, by design, will never use ccache.
==> Summary
🍺  /usr/local/Cellar/ccache/4.1: 64 files, 949.3KB
==> Installing px4/px4/px4-dev dependency: cmake
==> Pouring cmake-3.19.2.catalina.bottle.tar.gz
==> Caveats
Emacs Lisp files have been installed to:
  /usr/local/share/emacs/site-lisp/cmake
==> Summary
🍺  /usr/local/Cellar/cmake/3.19.2: 6,376 files, 64.0MB
==> Installing px4/px4/px4-dev dependency: discoteq/discoteq/flock
==> ./configure --prefix=/usr/local/Cellar/flock/0.4.0
==> make install
🍺  /usr/local/Cellar/flock/0.4.0: 6 files, 60.4KB, built in 10 seconds
==> Installing px4/px4/px4-dev dependency: fastcdr
==> cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local/Cellar/fastcdr/1.6.0 ..
==> make
==> make install
🍺  /usr/local/Cellar/fastcdr/1.6.0: 21 files, 436.8KB, built in 6 seconds
==> Installing px4/px4/px4-dev dependency: fastrtps
==> Pouring fastrtps-1.6.0.high_sierra.bottle.tar.gz
🍺  /usr/local/Cellar/fastrtps/1.6.0: 396 files, 5.8MB
==> Installing px4/px4/px4-dev dependency: gcc-arm-none-eabi
==> Copying binaries...
🍺  /usr/local/Cellar/gcc-arm-none-eabi/20200630: 6,624 files, 658.8MB, built in 41 seconds
==> Installing px4/px4/px4-dev dependency: genromfs
==> Patching
==> make
==> make PREFIX=/usr/local/Cellar/genromfs/0.5.2 install-bin
🍺  /usr/local/Cellar/genromfs/0.5.2: 6 files, 74.9KB, built in 3 seconds
==> Installing px4/px4/px4-dev dependency: kconfig-frontends
==> Pouring kconfig-frontends-3.7.0.0.yosemite.bottle.tar.gz
🍺  /usr/local/Cellar/kconfig-frontends/3.7.0.0: 18 files, 289.4KB
==> Installing px4/px4/px4-dev dependency: ninja
==> Pouring ninja-1.10.2.catalina.bottle.tar.gz
==> Caveats
zsh completions have been installed to:
  /usr/local/share/zsh/site-functions
==> Summary
🍺  /usr/local/Cellar/ninja/1.10.2: 7 files, 352.1KB
==> Installing px4/px4/px4-dev
==> PX4 Toolchain Installed
🍺  /usr/local/Cellar/px4-dev/1.11.0: 3 files, 6KB, built in 3 seconds
==> Caveats
==> openjdk
For the system Java wrappers to find this JDK, symlink it with
  sudo ln -sfn /usr/local/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk

openjdk is keg-only, which means it was not symlinked into /usr/local,
because it shadows the macOS `java` wrapper.

If you need to have openjdk first in your PATH run:
  echo 'export PATH="/usr/local/opt/openjdk/bin:$PATH"' >> ~/.zshrc

For compilers to find openjdk you may need to set:
  export CPPFLAGS="-I/usr/local/opt/openjdk/include"

==> bash-completion
Add the following line to your ~/.bash_profile:
  [[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
==> ccache
To install symlinks for compilers that will automatically use
ccache, prepend this directory to your PATH:
  /usr/local/opt/ccache/libexec

If this is an upgrade and you have previously added the symlinks to
your PATH, you may need to modify it to the path specified above so
it points to the current version.

NOTE: ccache can prevent some software from compiling.
ALSO NOTE: The brew command, by design, will never use ccache.
==> cmake
Emacs Lisp files have been installed to:
  /usr/local/share/emacs/site-lisp/cmake
==> ninja
zsh completions have been installed to:
  /usr/local/share/zsh/site-functions
```