### PR TITLE
Fix kconfig-frontends compilation on Mac M1

### DIFF
--- a/Formula/kconfig-frontends.rb
+++ b/Formula/kconfig-frontends.rb
@@ -14,6 +14,8 @@ class KconfigFrontends < Formula
     sha256 high_sierra: "9c02a28ea1c55253299560fbac6b7772425cc194f30fae5e055c6c9a664e1a08"
     sha256 mojave:      "9c02a28ea1c55253299560fbac6b7772425cc194f30fae5e055c6c9a664e1a08"
   end
+  
+  depends_on "ncurses" if DevelopmentTools.clang_build_version >= 1000
 
   depends_on "autoconf" => :build
 


### PR DESCRIPTION
kconfig-frontends fails to compile on M1 Mac (OSX 12.2.1, XCode CLT version 13.4.0.0.1.1651278267) with the following error:  `ld: symbol(s) not found for architecture x86_64`

This patch adds an ncurses dependency, which fixes the linker error above.