### PR TITLE
Workaround asio@1.10.8 failure to compile with current boost 1.89.0

### DIFF
--- a/Formula/asio@1.10.8.rb
+++ b/Formula/asio@1.10.8.rb
@@ -11,7 +11,7 @@ class AsioAT1108 < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "boost"
+  depends_on "boost@1.85"
 
   def install
     # Ensure C++11 compatibility


### PR DESCRIPTION
- Depend on boost@1.85 instead of current stable 1.89