### PR TITLE
px4-dev: drop unused discoteq/discoteq/flock dependency

### DIFF
--- a/Formula/px4-dev.rb
+++ b/Formula/px4-dev.rb
@@ -10,7 +10,6 @@ class Px4Dev < Formula
   depends_on "bash-completion"
   depends_on "ccache"
   depends_on "cmake"
-  depends_on "discoteq/discoteq/flock"
   depends_on "fastdds"
   depends_on "genromfs"
   depends_on "kconfig-frontends"


### PR DESCRIPTION
The `flock` CLI has not been invoked anywhere in the PX4 build system since NuttX 10. A full grep across PX4-Autopilot main, including the NuttX submodule (currently pinned to `px4_firmware_nuttx-10.3.0+`), finds zero shell or Makefile invocations of `flock`. The only matches are POSIX `flock(2)` syscalls in `platforms/posix/src/px4/common/main.cpp`, which come from libc and are unrelated to this formula.

This dep has been in `px4-dev` since 2020 (commit `3dfc20e`, ["Add flock for nuttx 9.1.x"](https://github.com/PX4/homebrew-px4/commit/3dfc20e)). It has not been needed for years.

Dropping it unblocks the PX4-Autopilot macOS CI, which has been red on every push to `main` since April 15 when Homebrew stopped auto-tapping cross-tap dependencies on macos-latest runners. The failure chain looked like this:

```
==> Fetching downloads for: px4-dev
##[warning]No available formula with the name "discoteq/discoteq/flock"
  (dependency of px4/px4/px4-dev).
This command requires the tap discoteq/discoteq.
##[error]No such keg: /opt/homebrew/Cellar/arm-gcc-bin@13
```

`brew install px4-dev` aborted before installing `ccache`, and subsequent `make` steps on the same runner failed with `ccache: command not found`.

Verified locally on macOS ARM64 (Sonoma, Homebrew 4.x):

- `brew uninstall --ignore-dependencies discoteq/discoteq/flock`
- `make distclean && make px4_fmu-v5_default && make px4_fmu-v6x_default` both succeeded
- `grep flock` across both build logs returned zero matches
- FLASH usage identical to baseline (1994976 B vs 1994984 B on v5, 1930096 B on v6x both runs)

If a future need for `flock` reappears on macOS, it's also now available as `util-linux/util-linux` in `homebrew/core`, so no need to keep the discoteq tap alive for this.