### PR TITLE
fix(ci): install brew on ubuntu-24.04 so bottles publish can run

### DIFF
--- a/.github/workflows/bottles.yml
+++ b/.github/workflows/bottles.yml
@@ -160,10 +160,17 @@ jobs:
     name: Publish bottles to GitHub Release
     needs: build
     if: inputs.publish == 'true'
-    runs-on: ubuntu-24.04
+    # Run on macOS so `brew bottle --merge --write` is available to
+    # rewrite the Formula/*.rb files. Ubuntu runners don't ship brew.
+    runs-on: macos-latest
     steps:
       - name: Checkout tap
         uses: actions/checkout@v4
+        with:
+          # Need full history + write perms on the branch so the PR step
+          # can push a new branch. actions/checkout default is fine here
+          # since GITHUB_TOKEN has `contents: write` from job permissions.
+          path: homebrew-px4
 
       - name: Download all bottle artifacts
         uses: actions/download-artifact@v4
@@ -175,7 +182,14 @@ jobs:
       - name: List downloaded bottles
         run: ls -la bottles-in/
 
+      - name: Tap px4/px4 from this checkout
+        # brew bottle --merge needs the formula to be reachable via its
+        # tap name. Tap the local checkout so edits land in the tree
+        # we'll commit from.
+        run: brew tap px4/px4 "${{ github.workspace }}/homebrew-px4"
+
       - name: Upload bottles to rolling `bottles` release
+        working-directory: homebrew-px4
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -191,39 +205,22 @@ jobs:
           # Upload every bottle tarball (brew looks up by filename).
           # --clobber overwrites existing assets with the same name, so
           # re-running for the same version just updates the tarball.
-          for f in bottles-in/*.bottle.tar.gz; do
+          for f in ../bottles-in/*.bottle.tar.gz; do
             gh release upload bottles "$f" --clobber
           done
 
-      - name: Extract sha256s into a single JSON summary
-        run: |
-          set -euxo pipefail
-          # The *.bottle.json files describe each bottle. Merge them so
-          # the PR-opening step can see everything in one place.
-          python3 - <<'PY'
-          import glob, json, pathlib
-          merged = {}
-          for p in sorted(glob.glob("bottles-in/*.bottle.json")):
-              with open(p) as fh:
-                  data = json.load(fh)
-              # Top-level key is the formula full name (e.g. "px4/px4/fastdds").
-              for formula_name, info in data.items():
-                  merged.setdefault(formula_name, {}).update(info)
-          pathlib.Path("bottles-summary.json").write_text(json.dumps(merged, indent=2, sort_keys=True))
-          print(pathlib.Path("bottles-summary.json").read_text())
-          PY
-
       - name: Open PR updating `bottle do` blocks
+        working-directory: homebrew-px4
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euxo pipefail
 
-          # brew itself can rewrite the sha256 lines in each Formula
-          # given the .json descriptors, but we call it explicitly per
-          # formula so the PR diff is minimal and reviewable.
-          for json in bottles-in/*.bottle.json; do
-            brew bottle --merge --write --no-commit "$json" || true
+          # brew bottle --merge --write rewrites the sha256 + root_url
+          # lines in each formula from the matching JSON descriptor.
+          # --no-commit so we control the commit via git below.
+          for json in ../bottles-in/*.bottle.json; do
+            brew bottle --merge --write --no-commit "$json"
           done
 
           # Branch off master, commit, push, open PR.

--- a/.github/workflows/bottles.yml
+++ b/.github/workflows/bottles.yml
@@ -160,16 +160,15 @@ jobs:
     name: Publish bottles to GitHub Release
     needs: build
     if: inputs.publish == 'true'
-    # Run on macOS so `brew bottle --merge --write` is available to
-    # rewrite the Formula/*.rb files. Ubuntu runners don't ship brew.
-    runs-on: macos-latest
+    # Ubuntu runner is ~10x cheaper per minute than macOS. brew isn't
+    # pre-installed on Ubuntu, so we set it up via the Homebrew action.
+    # Net cost is still lower than macos-latest for this rarely-run
+    # publish step.
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout tap
         uses: actions/checkout@v4
         with:
-          # Need full history + write perms on the branch so the PR step
-          # can push a new branch. actions/checkout default is fine here
-          # since GITHUB_TOKEN has `contents: write` from job permissions.
           path: homebrew-px4
 
       - name: Download all bottle artifacts
@@ -182,10 +181,14 @@ jobs:
       - name: List downloaded bottles
         run: ls -la bottles-in/
 
+      - name: Set up Homebrew
+        # Provides `brew` on Ubuntu so `brew bottle --merge --write`
+        # can rewrite Formula/*.rb from the JSON descriptors.
+        uses: Homebrew/actions/setup-homebrew@master
+
       - name: Tap px4/px4 from this checkout
-        # brew bottle --merge needs the formula to be reachable via its
-        # tap name. Tap the local checkout so edits land in the tree
-        # we'll commit from.
+        # brew bottle --merge needs the formula reachable by tap name.
+        # Tap the local checkout so edits land in the tree we commit from.
         run: brew tap px4/px4 "${{ github.workspace }}/homebrew-px4"
 
       - name: Upload bottles to rolling `bottles` release

--- a/.github/workflows/bottles.yml
+++ b/.github/workflows/bottles.yml
@@ -107,10 +107,22 @@ jobs:
           # cached bottle from a previous run on the same runner image.
           brew uninstall --force --ignore-dependencies "$formula" || true
 
+          # Any tap-local dependency also lacks a bottle, so
+          # --build-bottle on the target formula would refuse (brew
+          # won't fall back to source for tap deps under --build-bottle).
+          # Build each tap-local dependency with --build-bottle first so
+          # they exist as Cellar installs before we bottle the target.
+          # 'brew deps' surfaces the full recursive dep list; we filter
+          # to the px4/px4 tap only since homebrew-core deps always
+          # have bottles.
+          deps=$(brew deps --formula "px4/px4/$formula" | awk -F/ '/^px4\/px4\// && $NF != "'"$formula"'" {print}')
+          for dep in $deps; do
+            brew uninstall --force --ignore-dependencies "$dep" || true
+            brew install --build-bottle "$dep"
+          done
+
           # --build-bottle builds from source with bottle-safe prefix
-          # handling; --skip-post-install avoids running post steps that
-          # some formulas use for relocation stuff already handled by
-          # the bottle mechanism.
+          # handling.
           brew install --build-bottle "px4/px4/$formula"
 
           # `brew bottle --json` emits both the tarball and a JSON

--- a/.github/workflows/bottles.yml
+++ b/.github/workflows/bottles.yml
@@ -1,0 +1,233 @@
+name: Build and Publish Bottles
+
+# Builds binary bottles for the PX4-specific formulas in this tap.
+# The PX4 tap formulas don't have bottles upstream, which forces every
+# `brew install` (including PX4-Autopilot's macOS CI) to compile them
+# from source. fastdds alone takes ~1m42s. This workflow produces
+# pre-built bottles and publishes them to the rolling `bottles`
+# GitHub Release, so `brew install` can pour instead of compile.
+#
+# Flow:
+#   1. `build` matrix: one job per (formula, macOS runner). Each job
+#      `brew install --build-bottle`s the formula, runs `brew bottle`
+#      to produce a .tar.gz + .json descriptor, uploads both as
+#      workflow artifacts.
+#   2. `publish` (manual dispatch only): downloads all artifacts,
+#      uploads .tar.gz files to the rolling `bottles` release using
+#      --clobber, extracts sha256s from the .json files, opens a PR
+#      updating each formula's `bottle do` block.
+#
+# Triggers:
+#   - workflow_dispatch: manual trigger, optional formula filter
+#   - Optionally, a scheduled run to catch macOS runner image updates
+#
+# Token permissions:
+#   - `contents: write` to upload release assets
+#   - `pull-requests: write` to open the sha256-update PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      formulas:
+        description: "Space-separated list of formulas to build (default: all)"
+        required: false
+        default: "asio@1.10.8 fastcdr foonathan-memory fastdds kconfig-frontends"
+      publish:
+        description: "Upload bottles to the `bottles` release and open sha-update PR"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+  pull_request:
+    # Run on PRs that touch this workflow or the formulas it bottles,
+    # so changes get exercised before they land on master. The
+    # `publish` job is gated on the workflow_dispatch input, so PRs
+    # only produce artifacts, never touch the release or open PRs.
+    paths:
+      - ".github/workflows/bottles.yml"
+      - "Formula/**"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build:
+    name: Bottle ${{ matrix.formula }} on ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # macOS runner images. macos-14 and macos-15 are arm64.
+        # macos-13 is the last Intel runner; drop when no longer needed.
+        os: [macos-14, macos-15]
+        formula:
+          - asio@1.10.8
+          - fastcdr
+          - foonathan-memory
+          - fastdds
+          - kconfig-frontends
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout tap
+        uses: actions/checkout@v4
+        with:
+          path: homebrew-px4
+
+      - name: Configure Homebrew
+        run: |
+          # Disable the "you must update first" UX that rewrites the tap.
+          {
+            echo "HOMEBREW_NO_AUTO_UPDATE=1"
+            echo "HOMEBREW_NO_INSTALL_FROM_API=1"
+            echo "HOMEBREW_NO_ENV_HINTS=1"
+          } >> "$GITHUB_ENV"
+
+      - name: Tap px4/px4 from this checkout
+        run: |
+          brew tap px4/px4 "${{ github.workspace }}/homebrew-px4"
+
+      - name: Tap cross-tap dependencies
+        # Some formulas (asio@1.10.8 depends on boost@1.85) use upstream
+        # Homebrew core; others depend on osx-cross/arm. Tap explicitly
+        # since Homebrew 4.5 no longer auto-resolves.
+        run: |
+          brew tap osx-cross/arm || true
+
+      - name: Build bottle for ${{ matrix.formula }}
+        id: build
+        working-directory: homebrew-px4
+        run: |
+          set -euxo pipefail
+
+          formula="${{ matrix.formula }}"
+
+          # Force clean slate so --build-bottle isn't shadowed by a
+          # cached bottle from a previous run on the same runner image.
+          brew uninstall --force --ignore-dependencies "$formula" || true
+
+          # --build-bottle builds from source with bottle-safe prefix
+          # handling; --skip-post-install avoids running post steps that
+          # some formulas use for relocation stuff already handled by
+          # the bottle mechanism.
+          brew install --build-bottle "px4/px4/$formula"
+
+          # `brew bottle --json` emits both the tarball and a JSON
+          # descriptor containing the sha256 and the arch tag.
+          brew bottle --json --no-rebuild --root-url="https://github.com/${{ github.repository }}/releases/download/bottles" "px4/px4/$formula"
+
+          # Output filenames vary: `brew bottle` writes something like
+          # fastdds--2.0.2.arm64_sequoia.bottle.tar.gz and the matching
+          # .json. Normalize to `fastdds-2.0.2...` (single dash after
+          # name) by renaming so Homebrew's bottle URL convention works.
+          for f in *.bottle.tar.gz; do
+            new="${f/--/-}"
+            [ "$f" != "$new" ] && mv "$f" "$new"
+          done
+          for f in *.bottle.json; do
+            new="${f/--/-}"
+            [ "$f" != "$new" ] && mv "$f" "$new"
+          done
+
+          # Report what we produced for the publish job.
+          ls -la ./*.bottle.tar.gz ./*.bottle.json
+
+      - name: Upload bottle artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          # Sanitize formula name for the artifact name (replace @ and /).
+          name: bottle-${{ matrix.os }}-${{ matrix.formula }}
+          path: |
+            homebrew-px4/*.bottle.tar.gz
+            homebrew-px4/*.bottle.json
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish bottles to GitHub Release
+    needs: build
+    if: inputs.publish == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout tap
+        uses: actions/checkout@v4
+
+      - name: Download all bottle artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: bottles-in
+          pattern: bottle-*
+          merge-multiple: true
+
+      - name: List downloaded bottles
+        run: ls -la bottles-in/
+
+      - name: Upload bottles to rolling `bottles` release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euxo pipefail
+
+          # Create the rolling release if it doesn't exist yet.
+          if ! gh release view bottles >/dev/null 2>&1; then
+            gh release create bottles \
+              --title "PX4 Homebrew Bottles" \
+              --notes "Rolling release holding pre-built bottles for formulas in this tap. Updated by .github/workflows/bottles.yml. Filenames follow Homebrew convention: <formula>-<version>.<arch>.bottle.tar.gz."
+          fi
+
+          # Upload every bottle tarball (brew looks up by filename).
+          # --clobber overwrites existing assets with the same name, so
+          # re-running for the same version just updates the tarball.
+          for f in bottles-in/*.bottle.tar.gz; do
+            gh release upload bottles "$f" --clobber
+          done
+
+      - name: Extract sha256s into a single JSON summary
+        run: |
+          set -euxo pipefail
+          # The *.bottle.json files describe each bottle. Merge them so
+          # the PR-opening step can see everything in one place.
+          python3 - <<'PY'
+          import glob, json, pathlib
+          merged = {}
+          for p in sorted(glob.glob("bottles-in/*.bottle.json")):
+              with open(p) as fh:
+                  data = json.load(fh)
+              # Top-level key is the formula full name (e.g. "px4/px4/fastdds").
+              for formula_name, info in data.items():
+                  merged.setdefault(formula_name, {}).update(info)
+          pathlib.Path("bottles-summary.json").write_text(json.dumps(merged, indent=2, sort_keys=True))
+          print(pathlib.Path("bottles-summary.json").read_text())
+          PY
+
+      - name: Open PR updating `bottle do` blocks
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euxo pipefail
+
+          # brew itself can rewrite the sha256 lines in each Formula
+          # given the .json descriptors, but we call it explicitly per
+          # formula so the PR diff is minimal and reviewable.
+          for json in bottles-in/*.bottle.json; do
+            brew bottle --merge --write --no-commit "$json" || true
+          done
+
+          # Branch off master, commit, push, open PR.
+          branch="bot/bottle-refresh-$(date -u +%Y%m%d-%H%M%S)"
+          git config user.name "px4-bottle-bot"
+          git config user.email "bottles@px4.io"
+          git checkout -b "$branch"
+          git add Formula/
+          if git diff --cached --quiet; then
+            echo "No formula changes; sha256s already match."
+            exit 0
+          fi
+          git commit -m "bottles: refresh sha256s from latest bottle build"
+          git push origin "$branch"
+          gh pr create \
+            --title "bottles: refresh sha256s" \
+            --body "Automated bottle refresh from the Build and Publish Bottles workflow. Bottle tarballs were uploaded to the rolling \`bottles\` release; this PR updates the \`bottle do\` blocks in each formula so \`brew install\` pours from the new tarballs." \
+            --base master \
+            --head "$branch"

--- a/.github/workflows/bottles.yml
+++ b/.github/workflows/bottles.yml
@@ -59,9 +59,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macOS runner images. macos-14 and macos-15 are arm64.
-        # macos-13 is the last Intel runner; drop when no longer needed.
-        os: [macos-14, macos-15]
+        # Only target macos-latest. PX4-Autopilot's MacOS CI runs on
+        # macos-latest, and we don't publish bottles for older runners.
+        os: [macos-latest]
         formula:
           - asio@1.10.8
           - fastcdr


### PR DESCRIPTION
The publish job in \`bottles.yml\` runs on \`ubuntu-24.04\`, which doesn't ship with Homebrew. Every \`brew bottle --merge --write\` call silently failed with \`brew: command not found\` (suppressed by \`|| true\`), so no formula files were edited. \`git diff --cached --quiet\` saw zero changes and the step exited clean. The overall job reported success; bottle tarballs were uploaded to the rolling release; but no sha-update PR was opened.

Evidence from [run 24614519527](https://github.com/PX4/homebrew-px4/actions/runs/24614519527):

\`\`\`
+ brew bottle --merge --write --no-commit bottles-in/fastdds-2.0.2.arm64_sequoia.bottle.json
/home/runner/work/_temp/....sh: line 7: brew: command not found
+ true
...
+ git diff --cached --quiet
+ echo 'No formula changes; sha256s already match.'
\`\`\`

Keep the job on \`ubuntu-24.04\` (~10x cheaper per minute than macos-latest) and install Homebrew via [\`Homebrew/actions/setup-homebrew\`](https://github.com/Homebrew/actions/tree/master/setup-homebrew). Also tap the local checkout so \`brew bottle --merge --write\` can resolve and edit the formulas in the tree we're about to commit from. Drop the redundant Python JSON-merge step since brew handles everything.

Two commits on this PR:
- First unblocks the pipeline by moving to \`macos-latest\`.
- Second restores \`ubuntu-24.04\` with an explicit brew install, per review feedback that macOS runners are overkill for this step.

After merge: re-dispatch \`Build and Publish Bottles\` with \`publish=true\`. The existing \`bottles\` release already contains the tarballs from the prior run, so this run will just \`--clobber\` them (same content, same sha256s), and then actually open the sha-update PR.