### PR TITLE
fix(ci): install brew on ubuntu-24.04 so bottles publish can run

### DIFF
--- a/.github/workflows/bottles.yml
+++ b/.github/workflows/bottles.yml
@@ -160,10 +160,16 @@ jobs:
     name: Publish bottles to GitHub Release
     needs: build
     if: inputs.publish == 'true'
+    # Ubuntu runner is ~10x cheaper per minute than macOS. brew isn't
+    # pre-installed on Ubuntu, so we set it up via the Homebrew action.
+    # Net cost is still lower than macos-latest for this rarely-run
+    # publish step.
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout tap
         uses: actions/checkout@v4
+        with:
+          path: homebrew-px4
 
       - name: Download all bottle artifacts
         uses: actions/download-artifact@v4
@@ -175,7 +181,18 @@ jobs:
       - name: List downloaded bottles
         run: ls -la bottles-in/
 
+      - name: Set up Homebrew
+        # Provides `brew` on Ubuntu so `brew bottle --merge --write`
+        # can rewrite Formula/*.rb from the JSON descriptors.
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Tap px4/px4 from this checkout
+        # brew bottle --merge needs the formula reachable by tap name.
+        # Tap the local checkout so edits land in the tree we commit from.
+        run: brew tap px4/px4 "${{ github.workspace }}/homebrew-px4"
+
       - name: Upload bottles to rolling `bottles` release
+        working-directory: homebrew-px4
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -191,39 +208,22 @@ jobs:
           # Upload every bottle tarball (brew looks up by filename).
           # --clobber overwrites existing assets with the same name, so
           # re-running for the same version just updates the tarball.
-          for f in bottles-in/*.bottle.tar.gz; do
+          for f in ../bottles-in/*.bottle.tar.gz; do
             gh release upload bottles "$f" --clobber
           done
 
-      - name: Extract sha256s into a single JSON summary
-        run: |
-          set -euxo pipefail
-          # The *.bottle.json files describe each bottle. Merge them so
-          # the PR-opening step can see everything in one place.
-          python3 - <<'PY'
-          import glob, json, pathlib
-          merged = {}
-          for p in sorted(glob.glob("bottles-in/*.bottle.json")):
-              with open(p) as fh:
-                  data = json.load(fh)
-              # Top-level key is the formula full name (e.g. "px4/px4/fastdds").
-              for formula_name, info in data.items():
-                  merged.setdefault(formula_name, {}).update(info)
-          pathlib.Path("bottles-summary.json").write_text(json.dumps(merged, indent=2, sort_keys=True))
-          print(pathlib.Path("bottles-summary.json").read_text())
-          PY
-
       - name: Open PR updating `bottle do` blocks
+        working-directory: homebrew-px4
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euxo pipefail
 
-          # brew itself can rewrite the sha256 lines in each Formula
-          # given the .json descriptors, but we call it explicitly per
-          # formula so the PR diff is minimal and reviewable.
-          for json in bottles-in/*.bottle.json; do
-            brew bottle --merge --write --no-commit "$json" || true
+          # brew bottle --merge --write rewrites the sha256 + root_url
+          # lines in each formula from the matching JSON descriptor.
+          # --no-commit so we control the commit via git below.
+          for json in ../bottles-in/*.bottle.json; do
+            brew bottle --merge --write --no-commit "$json"
           done
 
           # Branch off master, commit, push, open PR.


### PR DESCRIPTION
The `publish` job in `bottles.yml` runs on `ubuntu-24.04`, which doesn't ship with Homebrew. Every `brew bottle --merge --write` call silently failed with `brew: command not found` (suppressed by `|| true`), so no formula files were edited. `git diff --cached --quiet` saw zero changes and the step exited clean. The overall job reported success and the bottle tarballs were uploaded to the rolling `bottles` release, but no sha-update PR was opened.

Evidence from [run 24614519527](https://github.com/PX4/homebrew-px4/actions/runs/24614519527):

```
+ brew bottle --merge --write --no-commit bottles-in/fastdds-2.0.2.arm64_sequoia.bottle.json
/home/runner/work/_temp/....sh: line 7: brew: command not found
+ true
...
+ git diff --cached --quiet
+ echo 'No formula changes; sha256s already match.'
```

Keep the job on `ubuntu-24.04` (~10x cheaper per minute than macos-latest) and install Homebrew via [`Homebrew/actions/setup-homebrew`](https://github.com/Homebrew/actions/tree/master/setup-homebrew). Also tap the local checkout so `brew bottle --merge --write` can resolve and edit the formulas in the tree we commit from. Upload tarballs from within the checkout directory so `gh release upload` paths are consistent, and drop the redundant Python JSON-merge step since brew handles everything.

Supersedes #106 (which had merge conflicts from a branching mishap; same fix, cleanly based on current master).

After merge: re-dispatch `Build and Publish Bottles` with `publish=true`. The existing `bottles` release already contains the tarballs, so the run will just `--clobber` them (same content, same sha256s) and this time open the sha-update PR that references the bottles from each formula's `bottle do` block.