### PR TITLE
fix(ci): untap px4/px4 before tapping from local checkout

### DIFF
--- a/.github/workflows/bottles.yml
+++ b/.github/workflows/bottles.yml
@@ -187,9 +187,13 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
 
       - name: Tap px4/px4 from this checkout
-        # brew bottle --merge needs the formula reachable by tap name.
-        # Tap the local checkout so edits land in the tree we commit from.
-        run: brew tap px4/px4 "${{ github.workspace }}/homebrew-px4"
+        # setup-homebrew auto-taps px4/px4 from the remote, which
+        # points at this repo on GitHub instead of our local checkout.
+        # Untap and re-tap from the local path so brew bottle --merge
+        # --write edits land in the tree we commit from.
+        run: |
+          brew untap px4/px4 || true
+          brew tap px4/px4 "${{ github.workspace }}/homebrew-px4"
 
       - name: Upload bottles to rolling `bottles` release
         working-directory: homebrew-px4


### PR DESCRIPTION
`Homebrew/actions/setup-homebrew` auto-taps the repository it ran in, so `px4/px4` is already registered as `https://github.com/PX4/homebrew-px4` by the time our tap step runs. Trying to register the same tap name from a local path fails with:

```
Tap px4/px4 remote mismatch.
https://github.com/PX4/homebrew-px4 != /home/runner/work/homebrew-px4/homebrew-px4/homebrew-px4
```

Untap first, then tap from the local path so `brew bottle --merge --write` edits land in the tree we commit from.

Evidence: [run 24614887977](https://github.com/PX4/homebrew-px4/actions/runs/24614887977) published all 5 bottles to the release successfully, but the `publish` job failed at the tap step for this reason before the sha-update PR could be opened.

After merge: re-dispatch `Build and Publish Bottles` with `publish=true` to complete the pipeline (tarballs already in the release, but we need the follow-up PR that adds `bottle do` blocks to each formula).