### PR TITLE
fix(ci): drop retap in publish job, let setup-homebrew handle it

### DIFF
--- a/.github/workflows/bottles.yml
+++ b/.github/workflows/bottles.yml
@@ -166,10 +166,13 @@ jobs:
     # publish step.
     runs-on: ubuntu-24.04
     steps:
+      # Checkout lands at $GITHUB_WORKSPACE (the default path).
+      # Homebrew/actions/setup-homebrew symlinks px4/px4 from that
+      # exact path into its tap directory, so we need the checkout at
+      # the default location, not a subdir, for the tap to resolve to
+      # the tree we commit from.
       - name: Checkout tap
         uses: actions/checkout@v4
-        with:
-          path: homebrew-px4
 
       - name: Download all bottle artifacts
         uses: actions/download-artifact@v4
@@ -182,21 +185,15 @@ jobs:
         run: ls -la bottles-in/
 
       - name: Set up Homebrew
-        # Provides `brew` on Ubuntu so `brew bottle --merge --write`
-        # can rewrite Formula/*.rb from the JSON descriptors.
+        # Provides `brew` on Ubuntu and auto-taps px4/px4 from our
+        # checkout so `brew bottle --merge --write` can resolve and
+        # edit the formulas in the tree we commit from. No separate
+        # `brew tap` step needed; trying to re-tap triggers a
+        # "remote mismatch" error or (worse) deletes our checkout on
+        # `brew untap` since the tap is a symlink into it.
         uses: Homebrew/actions/setup-homebrew@master
 
-      - name: Tap px4/px4 from this checkout
-        # setup-homebrew auto-taps px4/px4 from the remote, which
-        # points at this repo on GitHub instead of our local checkout.
-        # Untap and re-tap from the local path so brew bottle --merge
-        # --write edits land in the tree we commit from.
-        run: |
-          brew untap px4/px4 || true
-          brew tap px4/px4 "${{ github.workspace }}/homebrew-px4"
-
       - name: Upload bottles to rolling `bottles` release
-        working-directory: homebrew-px4
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -212,12 +209,11 @@ jobs:
           # Upload every bottle tarball (brew looks up by filename).
           # --clobber overwrites existing assets with the same name, so
           # re-running for the same version just updates the tarball.
-          for f in ../bottles-in/*.bottle.tar.gz; do
+          for f in bottles-in/*.bottle.tar.gz; do
             gh release upload bottles "$f" --clobber
           done
 
       - name: Open PR updating `bottle do` blocks
-        working-directory: homebrew-px4
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -225,8 +221,10 @@ jobs:
 
           # brew bottle --merge --write rewrites the sha256 + root_url
           # lines in each formula from the matching JSON descriptor.
-          # --no-commit so we control the commit via git below.
-          for json in ../bottles-in/*.bottle.json; do
+          # --no-commit so we control the commit via git below. Because
+          # setup-homebrew tapped px4/px4 from this workspace, the
+          # edits land on the checkout we commit from.
+          for json in bottles-in/*.bottle.json; do
             brew bottle --merge --write --no-commit "$json"
           done
 


### PR DESCRIPTION
`Homebrew/actions/setup-homebrew` auto-taps the workflow's repo from `$GITHUB_WORKSPACE` as a symlink into the tap directory. The explicit `brew untap px4/px4 || true` + `brew tap px4/px4 <path>` step added in #108 deleted the checkout (`brew untap` runs `rm -rf` on the tap target, and the target was a symlink to our code) and then failed re-tapping because the source path was gone.

Evidence from [run 24615040154](https://github.com/PX4/homebrew-px4/actions/runs/24615040154):

```
Untapping px4/px4...
Untapped 23 formulae (83 files, 654.0KB).
==> Tapping px4/px4
fatal: repository '/home/runner/work/homebrew-px4/homebrew-px4/homebrew-px4' does not exist
##[error]Failure while executing; `git clone ...` exited with 128.
```

Fix:

- Drop the retap step entirely. `setup-homebrew` already points the `px4/px4` tap at `$GITHUB_WORKSPACE`, which is where `brew bottle --merge --write` will edit the formulas and where we commit from.
- Drop `path: homebrew-px4` on `actions/checkout` so the code lands at `$GITHUB_WORKSPACE` (the default), matching where setup-homebrew symlinks the tap.

After merge: re-dispatch `Build and Publish Bottles` with `publish=true`. The existing `bottles` release already has the tarballs, so the run will just clobber them and finally open the sha-update PR.