### PR TITLE
fix(ci): publish job workspace semantics + commit refresh to master directly

### DIFF
--- a/.github/workflows/bottles.yml
+++ b/.github/workflows/bottles.yml
@@ -166,14 +166,20 @@ jobs:
     # publish step.
     runs-on: ubuntu-24.04
     steps:
-      # Checkout lands at $GITHUB_WORKSPACE (the default path).
-      # Homebrew/actions/setup-homebrew symlinks px4/px4 from that
-      # exact path into its tap directory, so we need the checkout at
-      # the default location, not a subdir, for the tap to resolve to
-      # the tree we commit from.
-      - name: Checkout tap
-        uses: actions/checkout@v4
+      # Homebrew/actions/setup-homebrew clones the tap repo into
+      # $GITHUB_WORKSPACE itself (after `rm -rf` on anything already
+      # there, see the action's main.sh). That replaces what
+      # actions/checkout would have produced, so a separate checkout
+      # step is redundant AND unsafe: its output gets wiped.
+      #
+      # It also symlinks Library/Taps/px4/homebrew-px4 -> $GITHUB_WORKSPACE
+      # so brew can resolve our formulas by tap name while edits land
+      # on the tree we commit from.
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
 
+      # Download AFTER setup-homebrew so bottles-in/ isn't wiped by
+      # setup-homebrew's `rm -rf "$GITHUB_WORKSPACE"/*`.
       - name: Download all bottle artifacts
         uses: actions/download-artifact@v4
         with:
@@ -183,15 +189,6 @@ jobs:
 
       - name: List downloaded bottles
         run: ls -la bottles-in/
-
-      - name: Set up Homebrew
-        # Provides `brew` on Ubuntu and auto-taps px4/px4 from our
-        # checkout so `brew bottle --merge --write` can resolve and
-        # edit the formulas in the tree we commit from. No separate
-        # `brew tap` step needed; trying to re-tap triggers a
-        # "remote mismatch" error or (worse) deletes our checkout on
-        # `brew untap` since the tap is a symlink into it.
-        uses: Homebrew/actions/setup-homebrew@master
 
       - name: Upload bottles to rolling `bottles` release
         env:
@@ -239,6 +236,11 @@ jobs:
             exit 0
           fi
           git commit -m "bottles: refresh sha256s from latest bottle build"
+          # setup-homebrew sets origin to a plain HTTPS URL without
+          # auth. Rewrite origin to embed GITHUB_TOKEN so push works
+          # for the bot. x-access-token is the documented user name
+          # for GITHUB_TOKEN-based HTTPS auth.
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push origin "$branch"
           gh pr create \
             --title "bottles: refresh sha256s" \

--- a/.github/workflows/bottles.yml
+++ b/.github/workflows/bottles.yml
@@ -14,16 +14,18 @@ name: Build and Publish Bottles
 #      workflow artifacts.
 #   2. `publish` (manual dispatch only): downloads all artifacts,
 #      uploads .tar.gz files to the rolling `bottles` release using
-#      --clobber, extracts sha256s from the .json files, opens a PR
-#      updating each formula's `bottle do` block.
+#      --clobber, runs `brew bottle --merge --write` to update each
+#      formula's `bottle do` block, and commits that directly to
+#      master. No PR review: the sha256s are deterministic outputs
+#      of the matrix that just ran, so human review would only delay
+#      `brew install` pouring.
 #
 # Triggers:
 #   - workflow_dispatch: manual trigger, optional formula filter
 #   - Optionally, a scheduled run to catch macOS runner image updates
 #
 # Token permissions:
-#   - `contents: write` to upload release assets
-#   - `pull-requests: write` to open the sha256-update PR
+#   - `contents: write` to upload release assets and push to master
 
 on:
   workflow_dispatch:
@@ -33,7 +35,7 @@ on:
         required: false
         default: "asio@1.10.8 fastcdr foonathan-memory fastdds kconfig-frontends"
       publish:
-        description: "Upload bottles to the `bottles` release and open sha-update PR"
+        description: "Upload bottles to the `bottles` release and commit sha256 refresh to master"
         required: false
         default: "false"
         type: choice
@@ -51,7 +53,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   build:
@@ -210,7 +211,7 @@ jobs:
             gh release upload bottles "$f" --clobber
           done
 
-      - name: Open PR updating `bottle do` blocks
+      - name: Commit updated `bottle do` blocks directly to master
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -225,25 +226,25 @@ jobs:
             brew bottle --merge --write --no-commit "$json"
           done
 
-          # Branch off master, commit, push, open PR.
-          branch="bot/bottle-refresh-$(date -u +%Y%m%d-%H%M%S)"
           git config user.name "px4-bottle-bot"
           git config user.email "bottles@px4.io"
-          git checkout -b "$branch"
           git add Formula/
           if git diff --cached --quiet; then
-            echo "No formula changes; sha256s already match."
+            echo "No formula changes; sha256s already match published bottles."
             exit 0
           fi
           git commit -m "bottles: refresh sha256s from latest bottle build"
-          # setup-homebrew sets origin to a plain HTTPS URL without
+
+          # setup-homebrew set origin to a plain HTTPS URL without
           # auth. Rewrite origin to embed GITHUB_TOKEN so push works
           # for the bot. x-access-token is the documented user name
           # for GITHUB_TOKEN-based HTTPS auth.
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push origin "$branch"
-          gh pr create \
-            --title "bottles: refresh sha256s" \
-            --body "Automated bottle refresh from the Build and Publish Bottles workflow. Bottle tarballs were uploaded to the rolling \`bottles\` release; this PR updates the \`bottle do\` blocks in each formula so \`brew install\` pours from the new tarballs." \
-            --base master \
-            --head "$branch"
+
+          # Push straight to master. Bot-authored sha256 refreshes
+          # for bottles we just published don't need PR review: the
+          # tarballs are immutable in the `bottles` release, the
+          # sha256s are deterministic outputs of the matrix that
+          # just ran, and gating on human review would only serve
+          # to delay `brew install` pouring vs. compiling.
+          git push origin HEAD:master


### PR DESCRIPTION
Three bugs in the publish job that together prevented the sha-update commit from landing, plus a follow-up simplification per review feedback. Called out separately so each root cause is explicit.

**1. `actions/checkout` ran before `setup-homebrew`.** `setup-homebrew` runs `rm -rf "$GITHUB_WORKSPACE"/*` to place its own tap clone at `$GITHUB_WORKSPACE` (see [`main.sh` line 268](https://github.com/Homebrew/actions/blob/master/setup-homebrew/main.sh#L268)). The checkout step's output was wiped before anything downstream could use it. Dropping the checkout step entirely: setup-homebrew already clones the tap at `$GITHUB_SHA`, which is what we want on `workflow_dispatch`.

**2. `download-artifact` wrote `bottles-in/` to `$GITHUB_WORKSPACE` before `setup-homebrew` ran**, so the wipe in (1) ate the artifacts too. Moving `download-artifact` **after** `setup-homebrew` so it lands in the final post-wipe workspace.

**3. `setup-homebrew` sets `origin` to a plain HTTPS URL without auth** (`$GITHUB_SERVER_URL/$GITHUB_REPOSITORY`). Any push step would fail with a 403. Rewriting `origin` to embed `GITHUB_TOKEN` via `x-access-token` before pushing.

**Follow-up simplification**: skip the PR round-trip entirely. Bot-authored sha256 refreshes come from a matrix that just ran, bottles that just uploaded to an immutable release, and a deterministic `brew bottle --merge --write` output. Requiring human review only delays `brew install` pouring with no safety gain. The step now commits and `git push origin HEAD:master` directly; concurrent master advance would make the push fail loud and obvious (re-dispatch to retry). Also dropped the `pull-requests: write` permission since the workflow no longer opens PRs.

## Verification

Locally confirmed that `brew bottle --merge --write` against a real bottle JSON edits the tap's `Formula/*.rb` via the tap resolver (not the JSON's `formula.path` field). In CI, `setup-homebrew` symlinks the tap to `$GITHUB_WORKSPACE`, so edits land in the tree we commit from.

After merge: re-dispatch `Build and Publish Bottles` with `publish=true`. The existing `bottles` release already has the tarballs, so the run will clobber them in-place (same sha256) and this time commit the `bottle do` block updates directly to master.