### PR TITLE
Deprecate px4-sim, px4-sim-gazebo, px4-sim-jmavsim into no-op meta-formulas

### DIFF
--- a/Formula/px4-dev.rb
+++ b/Formula/px4-dev.rb
@@ -29,7 +29,16 @@ class Px4Dev < Formula
   #
   # See PX4/PX4-Autopilot PR #27127 for the migration.
 
+  deprecate! date: "2026-04-20", because: "macOS toolchain is installed via Tools/setup/macos.sh in PX4-Autopilot"
+
   def install
+    opoo "px4-dev is deprecated and installs nothing."
+    opoo "Run ./Tools/setup/macos.sh from PX4-Autopilot to install the " \
+         "PX4 development toolchain."
+    opoo "If you relied on px4-dev to pull in arm-gcc-bin@13 or other " \
+         "toolchain packages, install them directly or via macos.sh. " \
+         "'brew autoremove' may uninstall them otherwise."
+
     (prefix/"DEPRECATED.md").write <<~DOC
       px4-dev is a no-op formula kept for backward compatibility.
 

--- a/Formula/px4-sim-gazebo.rb
+++ b/Formula/px4-sim-gazebo.rb
@@ -1,39 +1,65 @@
-class XRequirement < Requirement
-  fatal true
-
-  satisfy(build_env: false) { which("xquartz") }
-
-  def message
-    <<~EOS
-      XQuartz is required; install it via:
-        brew install --cask xquartz
-    EOS
-  end
-end
-
 class Px4SimGazebo < Formula
-  desc "PX4 Gazebo Simulation Toolkit"
-  homepage "http://px4.io"
-  url "https://raw.githubusercontent.com/PX4/PX4-Autopilot/main/Tools/px4.py"
-  version "1.16.0"
-  sha256 "7fc8a739658212cea302f446ef31c60babb5928ce98c9d990617f039e0da9ada"
-  depends_on "exiftool"
-  depends_on "glog"
-  depends_on "graphviz"
-  depends_on "gstreamer"
-  depends_on "opencv"
-  depends_on "osrf/simulation/gz-harmonic"
-  depends_on "protobuf"
-  depends_on "px4-dev"
+  desc "PX4 Gazebo simulation toolkit (deprecated no-op meta-formula)"
+  homepage "https://github.com/PX4/PX4-Autopilot"
+  url "https://raw.githubusercontent.com/PX4/homebrew-px4/master/README.md"
+  version "1.16.1"
+  sha256 "67dba75ba1ab3c958b0a059b02828a2b957b55d8916fb041a05d7edcc9b6d41a"
+
+  # This formula is intentionally a no-op as of April 2026.
+  #
+  # Historical context:
+  # px4-sim-gazebo was a meta-formula that pulled the Gazebo simulator
+  # and its dependencies in via depends_on, including cross-tap deps
+  # like osrf/simulation/gz-harmonic, plus px4-dev for the toolchain.
+  #
+  # In April 2026 Homebrew 4.5 stopped auto-tapping cross-tap
+  # dependencies. px4-dev was also deprecated in the same window (see
+  # PR #104), so this formula's dependency graph no longer makes sense.
+  #
+  # The Gazebo simulation setup path now lives in
+  # Tools/setup/macos.sh --sim-tools in PX4-Autopilot, alongside the
+  # rest of the simulation toolchain install.
+  #
+  # This formula is kept as a no-op so that older copies of macos.sh,
+  # cached Docker images, and third-party tutorials that still run
+  # `brew install px4-sim-gazebo` do not error out.
+
+  deprecate! date: "2026-04-20", because: "Gazebo toolchain is installed via Tools/setup/macos.sh --sim-tools"
 
   def install
-    mkdir_p "#{bin}/"
-    cp "px4.py", "#{bin}/px4-sim-gazebo.py"
-    ohai "PX4 Gazebo Simulation Installed"
+    opoo "px4-sim-gazebo is deprecated and installs nothing."
+    opoo "Run ./Tools/setup/macos.sh --sim-tools from PX4-Autopilot to " \
+         "install the Gazebo simulation toolchain."
+    opoo "If you relied on px4-sim-gazebo to pull in gz-harmonic, " \
+         "opencv, gstreamer, or other simulator deps, 'brew autoremove' " \
+         "may uninstall them. Reinstall them explicitly if you still " \
+         "need them."
+
+    (prefix/"DEPRECATED.md").write <<~DOC
+      px4-sim-gazebo is a no-op formula kept for backward compatibility.
+
+      The PX4 Gazebo simulation toolchain is now installed by
+      Tools/setup/macos.sh --sim-tools in the PX4-Autopilot repository.
+
+      See: https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/macos.sh
+    DOC
+  end
+
+  def caveats
+    <<~EOS
+      px4-sim-gazebo is deprecated and does nothing.
+
+      Install the PX4 Gazebo simulation toolchain via
+      Tools/setup/macos.sh --sim-tools in the PX4-Autopilot repository:
+
+          ./Tools/setup/macos.sh --sim-tools
+
+      That script taps and installs the required simulator packages
+      directly, replacing the work this formula used to do.
+    EOS
   end
 
   test do
-    output = shell_output("#{bin}/gz sim --version 2> /dev/null")
-    assert_match "Gazebo Sim, version 8*", output
+    assert_path_exists prefix/"DEPRECATED.md"
   end
 end

--- a/Formula/px4-sim-jmavsim.rb
+++ b/Formula/px4-sim-jmavsim.rb
@@ -1,20 +1,59 @@
-# This depends on Java 11 or 14 installed using e.g. AdoptOpenJDK
-# brew tap adoptopenjdk/openjdk
-# brew cask install adoptopenjdk14
-# Alternatively, Java can be installed from Oracle.
-
 class Px4SimJmavsim < Formula
-  desc "PX4 jMAVSim simulation"
-  homepage "http://px4.io"
-  url "https://raw.githubusercontent.com/PX4/PX4-Autopilot/master/Tools/px4.py"
-  version "1.11.0"
-  sha256 "7fc8a739658212cea302f446ef31c60babb5928ce98c9d990617f039e0da9ada"
-  depends_on "ant"
-  depends_on "px4-dev"
+  desc "PX4 jMAVSim simulation (deprecated no-op meta-formula)"
+  homepage "https://github.com/PX4/PX4-Autopilot"
+  url "https://raw.githubusercontent.com/PX4/homebrew-px4/master/README.md"
+  version "1.11.1"
+  sha256 "67dba75ba1ab3c958b0a059b02828a2b957b55d8916fb041a05d7edcc9b6d41a"
+
+  # This formula is intentionally a no-op as of April 2026.
+  #
+  # Historical context:
+  # px4-sim-jmavsim was a meta-formula that pulled in ant and px4-dev
+  # to provide the jMAVSim Java-based simulator environment.
+  #
+  # px4-dev was deprecated in the same window (see PR #104), and the
+  # simulation toolchain install path now lives in
+  # Tools/setup/macos.sh --sim-tools in PX4-Autopilot.
+  #
+  # This formula is kept as a no-op so that older copies of macos.sh,
+  # cached Docker images, and third-party tutorials that still run
+  # `brew install px4-sim-jmavsim` do not error out.
+
+  deprecate! date: "2026-04-20", because: "jMAVSim toolchain is installed via Tools/setup/macos.sh --sim-tools"
 
   def install
-    mkdir_p "#{bin}/"
-    cp "px4.py", "#{bin}/px4-sim-jmavsim.py"
-    ohai "PX4 jMAVSim simulation installed"
+    opoo "px4-sim-jmavsim is deprecated and installs nothing."
+    opoo "Run ./Tools/setup/macos.sh --sim-tools from PX4-Autopilot to " \
+         "install the simulation toolchain."
+    opoo "If you relied on px4-sim-jmavsim to pull in ant, " \
+         "'brew autoremove' may uninstall it. Reinstall it explicitly " \
+         "if you still need it."
+
+    (prefix/"DEPRECATED.md").write <<~DOC
+      px4-sim-jmavsim is a no-op formula kept for backward compatibility.
+
+      The PX4 simulation toolchain is now installed by
+      Tools/setup/macos.sh --sim-tools in the PX4-Autopilot repository.
+
+      See: https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/macos.sh
+    DOC
+  end
+
+  def caveats
+    <<~EOS
+      px4-sim-jmavsim is deprecated and does nothing.
+
+      Install the PX4 simulation toolchain via
+      Tools/setup/macos.sh --sim-tools in the PX4-Autopilot repository:
+
+          ./Tools/setup/macos.sh --sim-tools
+
+      That script installs the required simulator packages directly,
+      replacing the work this formula used to do.
+    EOS
+  end
+
+  test do
+    assert_path_exists prefix/"DEPRECATED.md"
   end
 end

--- a/Formula/px4-sim.rb
+++ b/Formula/px4-sim.rb
@@ -24,7 +24,16 @@ class Px4Sim < Formula
   #
   # See PX4/homebrew-px4 PR #104 for the matching px4-dev deprecation.
 
+  deprecate! date: "2026-04-20", because: "simulation toolchain is installed via Tools/setup/macos.sh --sim-tools"
+
   def install
+    opoo "px4-sim is deprecated and installs nothing."
+    opoo "Run ./Tools/setup/macos.sh --sim-tools from PX4-Autopilot to " \
+         "install the simulation toolchain."
+    opoo "If you relied on px4-sim to pull in px4-sim-gazebo or " \
+         "px4-sim-jmavsim, 'brew autoremove' may uninstall them. " \
+         "Reinstall them explicitly if you still need them."
+
     (prefix/"DEPRECATED.md").write <<~DOC
       px4-sim is a no-op formula kept for backward compatibility.
 

--- a/Formula/px4-sim.rb
+++ b/Formula/px4-sim.rb
@@ -1,19 +1,55 @@
-# This formula is presented for compatiliby with older instructions.
-# Going forward Gazebo and/or jMAVSim can also be installed individually using
-# px4-sim-gazebo and px4-sim-jmavsim.
-
 class Px4Sim < Formula
-  desc "PX4 simulation toolchain"
-  homepage "http://px4.io"
-  url "https://raw.githubusercontent.com/PX4/PX4-Autopilot/master/Tools/px4.py"
-  version "1.11.0"
-  sha256 "7fc8a739658212cea302f446ef31c60babb5928ce98c9d990617f039e0da9ada"
-  depends_on "px4-sim-gazebo"
-  depends_on "px4-sim-jmavsim"
+  desc "PX4 simulation toolchain (deprecated no-op meta-formula)"
+  homepage "https://github.com/PX4/PX4-Autopilot"
+  url "https://raw.githubusercontent.com/PX4/homebrew-px4/master/README.md"
+  version "1.11.1"
+  sha256 "67dba75ba1ab3c958b0a059b02828a2b957b55d8916fb041a05d7edcc9b6d41a"
+
+  # This formula is intentionally a no-op as of April 2026.
+  #
+  # Historical context:
+  # px4-sim was a meta-formula that pulled in px4-sim-gazebo and
+  # px4-sim-jmavsim to install the PX4 simulation toolchain on macOS.
+  #
+  # The PX4 simulation setup path now lives entirely in
+  # Tools/setup/macos.sh in PX4-Autopilot, alongside the rest of the
+  # toolchain install. Keeping this formula as a meta-dependency
+  # duplicates that logic and drifts out of date whenever the set of
+  # supported simulators changes.
+  #
+  # This formula is kept as a no-op so that older copies of macos.sh,
+  # cached Docker images, and third-party tutorials that still run
+  # `brew install px4-sim` do not error out. They get a harmless
+  # no-op install instead.
+  #
+  # See PX4/homebrew-px4 PR #104 for the matching px4-dev deprecation.
 
   def install
-    mkdir_p "#{bin}/"
-    cp "px4.py", "#{bin}/px4-sim.py"
-    ohai "PX4 Simulation Installed"
+    (prefix/"DEPRECATED.md").write <<~DOC
+      px4-sim is a no-op formula kept for backward compatibility.
+
+      The PX4 simulation toolchain is now installed by
+      Tools/setup/macos.sh --sim-tools in the PX4-Autopilot repository.
+
+      See: https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/macos.sh
+    DOC
+  end
+
+  def caveats
+    <<~EOS
+      px4-sim is deprecated and does nothing.
+
+      Install the PX4 simulation toolchain via Tools/setup/macos.sh
+      in the PX4-Autopilot repository:
+
+          ./Tools/setup/macos.sh --sim-tools
+
+      That script installs the required simulator packages directly,
+      replacing the work this formula used to do.
+    EOS
+  end
+
+  test do
+    assert_path_exists prefix/"DEPRECATED.md"
   end
 end


### PR DESCRIPTION
Follows the pattern set in #104 for `px4-dev`. The three remaining meta-formulas in this tap (`px4-sim`, `px4-sim-gazebo`, `px4-sim-jmavsim`) all had dependency chains that broke under Homebrew 4.5's removal of cross-tap auto-resolution, and `px4-dev` (which two of them depended on) is now a no-op. The PX4 simulation toolchain install path now lives in [`Tools/setup/macos.sh --sim-tools`](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/macos.sh) in PX4-Autopilot, alongside the rest of the macOS setup.

Rather than keep chasing the dependency graph, each of these formulas is kept as a harmless no-op so that older copies of `macos.sh`, cached Docker images, and third-party tutorials that still run `brew install px4-sim*` don't error out.

To make the deprecation visible to users (not just on first install, but on every `brew upgrade` and `brew info`), this PR also adds the same treatment to `px4-dev`:

- `deprecate!` directive with a 1-year disable window, which prints the standard `has been deprecated` banner and gets picked up by `brew audit`
- Three `opoo` yellow warnings inside `def install` covering the no-op notice, the pointer at `Tools/setup/macos.sh`, and an explicit heads-up that `brew autoremove` may uninstall previously-transitive packages (arm-gcc-bin@13, gz-harmonic, opencv, gstreamer, ant, etc.)
- `caveats` block for the final reminder

Verified locally on macOS ARM64: `brew audit --strict` passes on all four formulas, `brew install --build-from-source` completes in under a second with the full warning chain printed, and `brew test` passes.

Out of scope and flagged here for follow-up: the `gcc-arm-none-eabi-*` formulas (4.7 through 9.x) are still in the tap, superseded by `osx-cross/arm/arm-gcc-bin@13`, and most point at dead Launchpad or Arm download URLs. They aren't broken by the 4.5 cross-tap change since they don't depend on other taps, but they're obvious cleanup candidates.